### PR TITLE
[WIP] Fixing relative paths in examples

### DIFF
--- a/examples/bert/agnews_classification_pytorch.py
+++ b/examples/bert/agnews_classification_pytorch.py
@@ -125,15 +125,21 @@ model = trainer.ptl_trainer.get_model()
 if trainer.ptl_trainer.global_rank == 0:
     # Mar file generation
 
+    bert_dir, _ = os.path.split(os.path.abspath(__file__))
+
     mar_config = {
         "MODEL_NAME": "bert_test",
-        "MODEL_FILE": "examples/bert/bert_train.py",
-        "HANDLER": "examples/bert/bert_handler.py",
+        "MODEL_FILE": os.path.join(bert_dir, "bert_train.py"),
+        "HANDLER": os.path.join(bert_dir, "bert_handler.py"),
         "SERIALIZED_FILE": os.path.join(args["checkpoint_dir"], args["model_name"]),
         "VERSION": "1",
         "EXPORT_PATH": args["checkpoint_dir"],
         "CONFIG_PROPERTIES": "https://kubeflow-dataset.s3.us-east-2.amazonaws.com/bert/config.properties",
-        "EXTRA_FILES": "examples/bert/bert-base-uncased-vocab.txt,examples/bert/index_to_name.json,examples/bert/wrapper.py",
+        "EXTRA_FILES": "{},{},{}".format(
+            os.path.join(bert_dir, "bert-base-uncased-vocab.txt"),
+            os.path.join(bert_dir, "index_to_name.json"),
+            os.path.join(bert_dir, "wrapper.py")
+        )
     }
 
     MarGeneration(mar_config=mar_config, mar_save_path=args["checkpoint_dir"])

--- a/examples/cifar10/cifar10_pytorch.py
+++ b/examples/cifar10/cifar10_pytorch.py
@@ -126,9 +126,11 @@ model = trainer.ptl_trainer.get_model()
 if trainer.ptl_trainer.global_rank == 0:
     # Mar file generation
 
+    cifar_dir, _ = os.path.split(os.path.abspath(__file__))
+
     mar_config = {
         "MODEL_NAME": "cifar10_test",
-        "MODEL_FILE": "examples/cifar10/cifar10_train.py",
+        "MODEL_FILE": os.path.join(cifar_dir, "cifar10_train.py"),
         "HANDLER": "image_classifier",
         "SERIALIZED_FILE": os.path.join(args["checkpoint_dir"], args["model_name"]),
         "VERSION": "1",


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

Current examples (cifar10 and bert) uses relative path based on the `pytorch_pipeline` repository. 

Using python code to find the base directory, so that can use the same code across different repos `pytorch_pipeline`, `pipelines`.

Tested it in local environment. Marking it as WIP, as it needs to be tested in cluster once. 